### PR TITLE
feature: figure support url. (#2586)

### DIFF
--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -30,7 +30,7 @@
       >
     {% endif %}
     <img
-      src="{% if include.cache_bust %}{{ include.path | relative_url | bust_file_cache }}{% else %}{{ include.path | relative_url }}{% endif %}"
+      src="{% if include.url %}{{ include.url }}{% elsif include.cache_bust %}{{ include.path | relative_url | bust_file_cache }}{% else %}{{ include.path | relative_url }}{% endif %}"
       {% if include.class %}
         class="{{ include.class }}"
       {% endif %}


### PR DESCRIPTION
This PR allows the `figure` to accept url as the src of the`<img>`. currently, it only supports the relative path.

```
// raw img
<img src="{{ image.url }}" alt="{{ image.description }}">

// assign url to figure                 
{% assign image_url = image.url %}
{% include figure.liquid url=image_url class="img-fluid rounded z-depth-1" zoomable=true %}
```

---------