### PR TITLE
fix: do not included downloaded assets in jekyll-minifier (#2749)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -286,7 +286,7 @@ sass:
 # -----------------------------------------------------------------------------
 
 jekyll-minifier:
-  exclude: ["robots.txt", "assets/js/search/*.js"]
+  exclude: ["robots.txt", "assets/js/search/*.js", "assets/libs/**/*"]
   uglifier_args:
     harmony: true
 


### PR DESCRIPTION
If `download: true`, the site deployment fails.
This caused e.g. issue #2548.

I believe the issue appears because the 3rd party downloaded libs rely on ES6 Syntax, which jekyll-minifier cannot work on correctly. Also, I think we do not need to minify 3rd party downloaded libs at all.

While this PR does **not** fix the issue above, it at least ensures that the site can be deployed with `download: true`. We still need better ES6 support as suggested in #2571.