### PR TITLE
Fix broken repo cards on /code/ page

### DIFF
--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -33,12 +33,12 @@
     <img
       class="only-light w-100"
       alt="{{ repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="https://github-readme-stats-anuraghazra.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
     <img
       class="only-dark w-100"
       alt="{{ repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="https://github-readme-stats-anuraghazra.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
   </a>
 </div>

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -23,12 +23,12 @@
     <img
       class="only-light w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_icons=true"
+      src="https://github-readme-stats-anuraghazra.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_icons=true"
     >
     <img
       class="only-dark w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_icons=true"
+      src="https://github-readme-stats-anuraghazra.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_icons=true"
     >
   </a>
 </div>


### PR DESCRIPTION
## Summary
Repo card images on https://sustainableurbansystems.com/code/ are all broken: the public `github-readme-stats.vercel.app` instance currently returns HTTP 503 `DEPLOYMENT_PAUSED`.

This switches both repository includes to the author's working deployment alias `github-readme-stats-anuraghazra.vercel.app` (verified returning valid card SVGs for light and dark themes).

## Changes
- `_includes/repository/repo.liquid` — repo pin cards
- `_includes/repository/repo_user.liquid` — user stat cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)