### PR TITLE
fix(bib): remove duplicated code fields on three entries

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -143,7 +143,6 @@
 	preview      = {sigradi-2024.jpg},
 	code         = {https://github.com/SustainableUrbanSystemsLab/CP-SIGRADI2024-Assessing-Solar-Potential-of-Buildings-Using-LiDAR-and-Footprint-Data},
 	google_scholar_id = {L8Ckcad2t8MC},
-	code         = {https://github.com/SustainableUrbanSystemsLab/CP-SIGRADI2024-Assessing-Solar-Potential-of-Buildings-Using-LiDAR-and-Footprint-Data}
 }
 
 @inproceedings{almaian2024heat,
@@ -159,7 +158,6 @@
 	preview      = {ibpc-2024-ma.png},
 	code         = {https://github.com/SustainableUrbanSystemsLab/CP-IBPC2024-3D-Heat-Transfer-Analysis-in-Architectural-Modeling},
 	google_scholar_id = {9ZlFYXVOiuMC},
-	code         = {https://github.com/SustainableUrbanSystemsLab/CP-IBPC2024-3D-Heat-Transfer-Analysis-in-Architectural-Modeling}
 }
 
 @inproceedings{dogan2024impact,
@@ -372,7 +370,6 @@
 	code         = {https://github.com/SustainableUrbanSystemsLab/CP-SimAUD-HeatFlux},
 	google_scholar_id = {qjMakFHDy7sC},
 	preview      = {sim-aud-2020-02.jpg},
-	code         = {https://github.com/SustainableUrbanSystemsLab/CP-SimAUD-HeatFlux}
 }
 
 @article{natanian2020energy,


### PR DESCRIPTION
pybtex rejects a duplicated field inside an entry (DuplicateField). The Eddy3D website pulls papers.bib at build time, and its deploy is currently failing on three paste-duplicated `code` fields (identical URLs — nothing is lost): vangelova2024sigradi, almaian2024heat, kastner2020solving. Blocking the Eddy3D 1.4.0.827 release publish.